### PR TITLE
Update langchain deps and OpenAI model

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,10 @@
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {
+                "@langchain/core": "^0.3.9",
+                "@langchain/openai": "^0.3.7",
                 "discord.js": "^14.12.1",
                 "dotenv": "^16.4.4",
-                "langchain": "^0.0.205",
                 "log-timestamp": "^0.3.0",
                 "mongoose": "^8.1.3",
                 "mongoose-long": "^0.8.0"
@@ -39,30 +40,6 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/@anthropic-ai/sdk": {
-            "version": "0.9.1",
-            "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.9.1.tgz",
-            "integrity": "sha512-wa1meQ2WSfoY8Uor3EdrJq0jTiZJoKoSii2ZVWRY1oN4Tlr5s59pADg9T79FTbPe1/se5c3pBeZgJL63wmuoBA==",
-            "dependencies": {
-                "@types/node": "^18.11.18",
-                "@types/node-fetch": "^2.6.4",
-                "abort-controller": "^3.0.0",
-                "agentkeepalive": "^4.2.1",
-                "digest-fetch": "^1.3.0",
-                "form-data-encoder": "1.7.2",
-                "formdata-node": "^4.3.2",
-                "node-fetch": "^2.6.7",
-                "web-streams-polyfill": "^3.2.1"
-            }
-        },
-        "node_modules/@anthropic-ai/sdk/node_modules/@types/node": {
-            "version": "18.19.17",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.17.tgz",
-            "integrity": "sha512-SzyGKgwPzuWp2SHhlpXKzCX0pIOfcI4V2eF37nNBJOhwlegQ83omtVQ1XxZpDE06V/d6AQvfQdPfnw0tRC//Ng==",
-            "dependencies": {
-                "undici-types": "~5.26.4"
             }
         },
         "node_modules/@babel/runtime": {
@@ -667,359 +644,21 @@
             "integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==",
             "dev": true
         },
-        "node_modules/@langchain/community": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/@langchain/community/-/community-0.0.3.tgz",
-            "integrity": "sha512-Mwnv3Ctrj1hJOC0jF9ar9JcWk5yPNp9y1E+XLmVfiKUoOkmpQXFWem0EP84ZIuinDS6oP+dHF/1kIKcU4YMFfQ==",
-            "dependencies": {
-                "@langchain/core": "~0.1.0",
-                "@langchain/openai": "~0.0.5",
-                "flat": "^5.0.2",
-                "langsmith": "~0.0.48",
-                "uuid": "^9.0.0",
-                "zod": "^3.22.3"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "@aws-crypto/sha256-js": "^5.0.0",
-                "@aws-sdk/client-bedrock-runtime": "^3.422.0",
-                "@aws-sdk/client-dynamodb": "^3.310.0",
-                "@aws-sdk/client-kendra": "^3.352.0",
-                "@aws-sdk/client-lambda": "^3.310.0",
-                "@aws-sdk/client-sagemaker-runtime": "^3.310.0",
-                "@aws-sdk/client-sfn": "^3.310.0",
-                "@aws-sdk/credential-provider-node": "^3.388.0",
-                "@clickhouse/client": "^0.2.5",
-                "@cloudflare/ai": "^1.0.12",
-                "@elastic/elasticsearch": "^8.4.0",
-                "@getmetal/metal-sdk": "*",
-                "@getzep/zep-js": "^0.9.0",
-                "@gomomento/sdk": "^1.51.1",
-                "@gomomento/sdk-core": "^1.51.1",
-                "@google-ai/generativelanguage": "^0.2.1",
-                "@gradientai/nodejs-sdk": "^1.2.0",
-                "@huggingface/inference": "^2.6.4",
-                "@mozilla/readability": "*",
-                "@opensearch-project/opensearch": "*",
-                "@pinecone-database/pinecone": "^1.1.0",
-                "@planetscale/database": "^1.8.0",
-                "@qdrant/js-client-rest": "^1.2.0",
-                "@raycast/api": "^1.55.2",
-                "@rockset/client": "^0.9.1",
-                "@smithy/eventstream-codec": "^2.0.5",
-                "@smithy/protocol-http": "^3.0.6",
-                "@smithy/signature-v4": "^2.0.10",
-                "@smithy/util-utf8": "^2.0.0",
-                "@supabase/postgrest-js": "^1.1.1",
-                "@supabase/supabase-js": "^2.10.0",
-                "@tensorflow-models/universal-sentence-encoder": "*",
-                "@tensorflow/tfjs-converter": "*",
-                "@tensorflow/tfjs-core": "*",
-                "@upstash/redis": "^1.20.6",
-                "@vercel/kv": "^0.2.3",
-                "@vercel/postgres": "^0.5.0",
-                "@writerai/writer-sdk": "^0.40.2",
-                "@xata.io/client": "^0.28.0",
-                "@xenova/transformers": "^2.5.4",
-                "@zilliz/milvus2-sdk-node": ">=2.2.7",
-                "cassandra-driver": "^4.7.2",
-                "chromadb": "*",
-                "closevector-common": "0.1.0-alpha.1",
-                "closevector-node": "0.1.0-alpha.10",
-                "closevector-web": "0.1.0-alpha.16",
-                "cohere-ai": ">=6.0.0",
-                "convex": "^1.3.1",
-                "faiss-node": "^0.5.1",
-                "firebase-admin": "^11.9.0",
-                "google-auth-library": "^8.9.0",
-                "googleapis": "^126.0.1",
-                "hnswlib-node": "^1.4.2",
-                "html-to-text": "^9.0.5",
-                "ioredis": "^5.3.2",
-                "jsdom": "*",
-                "llmonitor": "^0.5.9",
-                "lodash": "^4.17.21",
-                "mongodb": "^5.2.0",
-                "mysql2": "^3.3.3",
-                "neo4j-driver": "*",
-                "node-llama-cpp": "*",
-                "pg": "^8.11.0",
-                "pg-copy-streams": "^6.0.5",
-                "pickleparser": "^0.2.1",
-                "portkey-ai": "^0.1.11",
-                "redis": "^4.6.4",
-                "replicate": "^0.18.0",
-                "typeorm": "^0.3.12",
-                "typesense": "^1.5.3",
-                "usearch": "^1.1.1",
-                "vectordb": "^0.1.4",
-                "voy-search": "0.6.2",
-                "weaviate-ts-client": "^1.4.0",
-                "web-auth-library": "^1.0.3",
-                "ws": "^8.14.2"
-            },
-            "peerDependenciesMeta": {
-                "@aws-crypto/sha256-js": {
-                    "optional": true
-                },
-                "@aws-sdk/client-bedrock-runtime": {
-                    "optional": true
-                },
-                "@aws-sdk/client-dynamodb": {
-                    "optional": true
-                },
-                "@aws-sdk/client-kendra": {
-                    "optional": true
-                },
-                "@aws-sdk/client-lambda": {
-                    "optional": true
-                },
-                "@aws-sdk/client-sagemaker-runtime": {
-                    "optional": true
-                },
-                "@aws-sdk/client-sfn": {
-                    "optional": true
-                },
-                "@aws-sdk/credential-provider-node": {
-                    "optional": true
-                },
-                "@clickhouse/client": {
-                    "optional": true
-                },
-                "@cloudflare/ai": {
-                    "optional": true
-                },
-                "@elastic/elasticsearch": {
-                    "optional": true
-                },
-                "@getmetal/metal-sdk": {
-                    "optional": true
-                },
-                "@getzep/zep-js": {
-                    "optional": true
-                },
-                "@gomomento/sdk": {
-                    "optional": true
-                },
-                "@gomomento/sdk-core": {
-                    "optional": true
-                },
-                "@google-ai/generativelanguage": {
-                    "optional": true
-                },
-                "@gradientai/nodejs-sdk": {
-                    "optional": true
-                },
-                "@huggingface/inference": {
-                    "optional": true
-                },
-                "@mozilla/readability": {
-                    "optional": true
-                },
-                "@opensearch-project/opensearch": {
-                    "optional": true
-                },
-                "@pinecone-database/pinecone": {
-                    "optional": true
-                },
-                "@planetscale/database": {
-                    "optional": true
-                },
-                "@qdrant/js-client-rest": {
-                    "optional": true
-                },
-                "@raycast/api": {
-                    "optional": true
-                },
-                "@rockset/client": {
-                    "optional": true
-                },
-                "@smithy/eventstream-codec": {
-                    "optional": true
-                },
-                "@smithy/protocol-http": {
-                    "optional": true
-                },
-                "@smithy/signature-v4": {
-                    "optional": true
-                },
-                "@smithy/util-utf8": {
-                    "optional": true
-                },
-                "@supabase/postgrest-js": {
-                    "optional": true
-                },
-                "@supabase/supabase-js": {
-                    "optional": true
-                },
-                "@tensorflow-models/universal-sentence-encoder": {
-                    "optional": true
-                },
-                "@tensorflow/tfjs-converter": {
-                    "optional": true
-                },
-                "@tensorflow/tfjs-core": {
-                    "optional": true
-                },
-                "@upstash/redis": {
-                    "optional": true
-                },
-                "@vercel/kv": {
-                    "optional": true
-                },
-                "@vercel/postgres": {
-                    "optional": true
-                },
-                "@writerai/writer-sdk": {
-                    "optional": true
-                },
-                "@xata.io/client": {
-                    "optional": true
-                },
-                "@xenova/transformers": {
-                    "optional": true
-                },
-                "@zilliz/milvus2-sdk-node": {
-                    "optional": true
-                },
-                "cassandra-driver": {
-                    "optional": true
-                },
-                "chromadb": {
-                    "optional": true
-                },
-                "closevector-common": {
-                    "optional": true
-                },
-                "closevector-node": {
-                    "optional": true
-                },
-                "closevector-web": {
-                    "optional": true
-                },
-                "cohere-ai": {
-                    "optional": true
-                },
-                "convex": {
-                    "optional": true
-                },
-                "faiss-node": {
-                    "optional": true
-                },
-                "firebase-admin": {
-                    "optional": true
-                },
-                "google-auth-library": {
-                    "optional": true
-                },
-                "googleapis": {
-                    "optional": true
-                },
-                "hnswlib-node": {
-                    "optional": true
-                },
-                "html-to-text": {
-                    "optional": true
-                },
-                "ioredis": {
-                    "optional": true
-                },
-                "jsdom": {
-                    "optional": true
-                },
-                "llmonitor": {
-                    "optional": true
-                },
-                "lodash": {
-                    "optional": true
-                },
-                "mongodb": {
-                    "optional": true
-                },
-                "mysql2": {
-                    "optional": true
-                },
-                "neo4j-driver": {
-                    "optional": true
-                },
-                "node-llama-cpp": {
-                    "optional": true
-                },
-                "pg": {
-                    "optional": true
-                },
-                "pg-copy-streams": {
-                    "optional": true
-                },
-                "pickleparser": {
-                    "optional": true
-                },
-                "portkey-ai": {
-                    "optional": true
-                },
-                "redis": {
-                    "optional": true
-                },
-                "replicate": {
-                    "optional": true
-                },
-                "typeorm": {
-                    "optional": true
-                },
-                "typesense": {
-                    "optional": true
-                },
-                "usearch": {
-                    "optional": true
-                },
-                "vectordb": {
-                    "optional": true
-                },
-                "voy-search": {
-                    "optional": true
-                },
-                "weaviate-ts-client": {
-                    "optional": true
-                },
-                "web-auth-library": {
-                    "optional": true
-                },
-                "ws": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@langchain/community/node_modules/langsmith": {
-            "version": "0.0.70",
-            "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.0.70.tgz",
-            "integrity": "sha512-QFHrzo/efBowGPCxtObv7G40/OdwqQfGshavMbSJtHBgX+OMqnn4lCMqVeEwTdyue4lEcpwAsGNg5Vty91YIyw==",
-            "dependencies": {
-                "@types/uuid": "^9.0.1",
-                "commander": "^10.0.1",
-                "p-queue": "^6.6.2",
-                "p-retry": "4",
-                "uuid": "^9.0.0"
-            },
-            "bin": {
-                "langsmith": "dist/cli/main.cjs"
-            }
-        },
         "node_modules/@langchain/core": {
-            "version": "0.1.30",
-            "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.1.30.tgz",
-            "integrity": "sha512-3oqEKgwe7U/efieZrCC6BLwOHm4YPj27mRNBZLaB5BwPh3a7gXIevxEnbjN3o5j9kJqc5acG7nn35h7Wkrf2Ag==",
+            "version": "0.3.9",
+            "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.9.tgz",
+            "integrity": "sha512-Rttr9FuFwU+CWIoEyuLqQUPYg+3pKL1YpDgo3nvoDVhinoHqwGQ7aNGzZ/Sf+qASMi76sPSLm+75pHMJwwOiWg==",
+            "license": "MIT",
             "dependencies": {
                 "ansi-styles": "^5.0.0",
                 "camelcase": "6",
                 "decamelize": "1.2.0",
-                "js-tiktoken": "^1.0.8",
-                "langsmith": "~0.1.1",
-                "ml-distance": "^4.0.0",
+                "js-tiktoken": "^1.0.12",
+                "langsmith": "^0.1.56",
+                "mustache": "^4.2.0",
                 "p-queue": "^6.6.2",
                 "p-retry": "4",
-                "uuid": "^9.0.0",
+                "uuid": "^10.0.0",
                 "zod": "^3.22.4",
                 "zod-to-json-schema": "^3.22.3"
             },
@@ -1031,6 +670,7 @@
             "version": "6.3.0",
             "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
             "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+            "license": "MIT",
             "engines": {
                 "node": ">=10"
             },
@@ -1039,18 +679,21 @@
             }
         },
         "node_modules/@langchain/openai": {
-            "version": "0.0.14",
-            "resolved": "https://registry.npmjs.org/@langchain/openai/-/openai-0.0.14.tgz",
-            "integrity": "sha512-co6nRylPrLGY/C3JYxhHt6cxLq07P086O7K3QaZH7SFFErIN9wSzJonpvhZR07DEUq6eK6wKgh2ORxA/NcjSRQ==",
+            "version": "0.3.7",
+            "resolved": "https://registry.npmjs.org/@langchain/openai/-/openai-0.3.7.tgz",
+            "integrity": "sha512-3Jhyy2uKkymYu1iVK18sG2ASZVg0EQcmtTuEPVnrrFGYJ0EIPufejm6bE1ebOHZRc50kSxQwRFCAGrMatNtUiQ==",
+            "license": "MIT",
             "dependencies": {
-                "@langchain/core": "~0.1.13",
-                "js-tiktoken": "^1.0.7",
-                "openai": "^4.26.0",
+                "js-tiktoken": "^1.0.12",
+                "openai": "^4.67.2",
                 "zod": "^3.22.4",
                 "zod-to-json-schema": "^3.22.3"
             },
             "engines": {
                 "node": ">=18"
+            },
+            "peerDependencies": {
+                "@langchain/core": ">=0.2.26 <0.4.0"
             }
         },
         "node_modules/@mongodb-js/saslprep": {
@@ -1145,6 +788,7 @@
             "version": "2.6.11",
             "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.11.tgz",
             "integrity": "sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==",
+            "license": "MIT",
             "dependencies": {
                 "@types/node": "*",
                 "form-data": "^4.0.0"
@@ -1153,7 +797,8 @@
         "node_modules/@types/retry": {
             "version": "0.12.0",
             "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
-            "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="
+            "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+            "license": "MIT"
         },
         "node_modules/@types/semver": {
             "version": "7.5.7",
@@ -1162,25 +807,15 @@
             "dev": true
         },
         "node_modules/@types/uuid": {
-            "version": "9.0.8",
-            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
-            "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA=="
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+            "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+            "license": "MIT"
         },
         "node_modules/@types/webidl-conversions": {
             "version": "7.0.3",
             "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
             "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA=="
-        },
-        "node_modules/@types/whatwg-url": {
-            "version": "8.2.2",
-            "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
-            "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@types/node": "*",
-                "@types/webidl-conversions": "*"
-            }
         },
         "node_modules/@types/ws": {
             "version": "8.5.9",
@@ -1423,6 +1058,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
             "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+            "license": "MIT",
             "dependencies": {
                 "event-target-shim": "^5.0.0"
             },
@@ -1455,6 +1091,7 @@
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.5.0.tgz",
             "integrity": "sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==",
+            "license": "MIT",
             "dependencies": {
                 "humanize-ms": "^1.2.1"
             },
@@ -1491,6 +1128,7 @@
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
             "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+            "license": "MIT",
             "engines": {
                 "node": ">=10"
             },
@@ -1514,7 +1152,8 @@
         "node_modules/argparse": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true
         },
         "node_modules/args": {
             "version": "5.0.3",
@@ -1599,18 +1238,14 @@
         "node_modules/asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+            "license": "MIT"
         },
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true
-        },
-        "node_modules/base-64": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
-            "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA=="
         },
         "node_modules/base64-js": {
             "version": "1.5.1",
@@ -1629,20 +1264,17 @@
                     "type": "consulting",
                     "url": "https://feross.org/support"
                 }
-            ]
+            ],
+            "license": "MIT"
         },
         "node_modules/binary-extensions": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
             "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+            "dev": true,
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/binary-search": {
-            "version": "1.3.6",
-            "resolved": "https://registry.npmjs.org/binary-search/-/binary-search-1.3.6.tgz",
-            "integrity": "sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA=="
         },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
@@ -1754,14 +1386,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/charenc": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-            "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/chokidar": {
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -1831,6 +1455,7 @@
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
             "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "license": "MIT",
             "dependencies": {
                 "delayed-stream": "~1.0.0"
             },
@@ -1842,6 +1467,7 @@
             "version": "10.0.1",
             "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
             "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+            "license": "MIT",
             "engines": {
                 "node": ">=14"
             }
@@ -1893,14 +1519,6 @@
                 "node": ">= 8"
             }
         },
-        "node_modules/crypt": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-            "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/date-fns": {
             "version": "2.30.0",
             "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
@@ -1937,6 +1555,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
             "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -1951,17 +1570,9 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">=0.4.0"
-            }
-        },
-        "node_modules/digest-fetch": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/digest-fetch/-/digest-fetch-1.3.0.tgz",
-            "integrity": "sha512-CGJuv6iKNM7QyZlM2T3sPAdZWd/p9zQiRNS9G+9COUCwzWFTs0Xp8NF5iePx7wtvhDykReiRRrSeNb4oMmB8lA==",
-            "dependencies": {
-                "base-64": "^0.1.0",
-                "md5": "^2.3.0"
             }
         },
         "node_modules/dir-glob": {
@@ -2251,6 +1862,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
             "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
@@ -2258,12 +1870,8 @@
         "node_modules/eventemitter3": {
             "version": "4.0.7",
             "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-            "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
-        },
-        "node_modules/expr-eval": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/expr-eval/-/expr-eval-2.0.2.tgz",
-            "integrity": "sha512-4EMSHGOPSwAfBiibw3ndnP0AvjDWLsMvGOvWEZ2F96IGk0bIVdjQisOHxReSkE13mHcfbuCiXw+G4y0zv6N8Eg=="
+            "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+            "license": "MIT"
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
@@ -2360,14 +1968,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/flat": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-            "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
-            "bin": {
-                "flat": "cli.js"
-            }
-        },
         "node_modules/flat-cache": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
@@ -2389,9 +1989,10 @@
             "dev": true
         },
         "node_modules/form-data": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-            "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+            "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+            "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
@@ -2404,26 +2005,20 @@
         "node_modules/form-data-encoder": {
             "version": "1.7.2",
             "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
-            "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A=="
+            "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+            "license": "MIT"
         },
         "node_modules/formdata-node": {
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
             "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+            "license": "MIT",
             "dependencies": {
                 "node-domexception": "1.0.0",
                 "web-streams-polyfill": "4.0.0-beta.3"
             },
             "engines": {
                 "node": ">= 12.20"
-            }
-        },
-        "node_modules/formdata-node/node_modules/web-streams-polyfill": {
-            "version": "4.0.0-beta.3",
-            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
-            "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
-            "engines": {
-                "node": ">= 14"
             }
         },
         "node_modules/fs.realpath": {
@@ -2553,6 +2148,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
             "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+            "license": "MIT",
             "dependencies": {
                 "ms": "^2.0.0"
             }
@@ -2561,7 +2157,7 @@
             "version": "5.3.1",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
             "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">= 4"
             }
@@ -2621,11 +2217,6 @@
                 "node": ">= 12"
             }
         },
-        "node_modules/is-any-array": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/is-any-array/-/is-any-array-2.0.1.tgz",
-            "integrity": "sha512-UtilS7hLRu++wb/WBAw9bNuP1Eg04Ivn1vERJck8zJthEvXCBEBpGR/33u/xLKWEQf95803oalHrVDptcAvFdQ=="
-        },
         "node_modules/is-binary-path": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -2637,11 +2228,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/is-buffer": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
         },
         "node_modules/is-extglob": {
             "version": "2.1.1",
@@ -2699,9 +2285,10 @@
             "dev": true
         },
         "node_modules/js-tiktoken": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.10.tgz",
-            "integrity": "sha512-ZoSxbGjvGyMT13x6ACo9ebhDha/0FHdKA+OsQcMOWcm1Zs7r90Rhk5lhERLzji+3rA7EKpXCgwXcM5fF3DMpdA==",
+            "version": "1.0.15",
+            "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.15.tgz",
+            "integrity": "sha512-65ruOWWXDEZHHbAo7EjOcNxOGasQKbL4Fq3jEr2xsCqSsoOo6VVSqzWQb6PRIqypFSDcma4jO90YP0w5X8qVXQ==",
+            "license": "MIT",
             "dependencies": {
                 "base64-js": "^1.5.1"
             }
@@ -2710,6 +2297,7 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
             "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+            "dev": true,
             "dependencies": {
                 "argparse": "^2.0.1"
             },
@@ -2742,14 +2330,6 @@
             "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
             "dev": true
         },
-        "node_modules/jsonpointer": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
-            "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/kareem": {
             "version": "2.5.1",
             "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.5.1.tgz",
@@ -2767,282 +2347,26 @@
                 "json-buffer": "3.0.1"
             }
         },
-        "node_modules/langchain": {
-            "version": "0.0.205",
-            "resolved": "https://registry.npmjs.org/langchain/-/langchain-0.0.205.tgz",
-            "integrity": "sha512-NfayH81rm8s/hoPqAWJmO8W5lwHnH6eG/pjXkPlyHlxPW7mrY+t+bayCyWki64sB3WV36ivSnwCMvYGlpAjmkQ==",
+        "node_modules/langsmith": {
+            "version": "0.1.64",
+            "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.1.64.tgz",
+            "integrity": "sha512-fA827iH34G6zFzZx5kzbZcevtulqq8qo1e9g/Rn+L0TXuOJSKLMEfVbDbX6WD9laus9P8ItZcp27E5/DngOFHQ==",
+            "license": "MIT",
             "dependencies": {
-                "@anthropic-ai/sdk": "^0.9.1",
-                "@langchain/community": "~0.0.3",
-                "@langchain/core": "~0.1.0",
-                "@langchain/openai": "~0.0.5",
-                "binary-extensions": "^2.2.0",
-                "expr-eval": "^2.0.2",
-                "js-tiktoken": "^1.0.7",
-                "js-yaml": "^4.1.0",
-                "jsonpointer": "^5.0.1",
-                "langchainhub": "~0.0.6",
-                "langsmith": "~0.0.48",
-                "ml-distance": "^4.0.0",
-                "openapi-types": "^12.1.3",
+                "@types/uuid": "^10.0.0",
+                "commander": "^10.0.1",
+                "p-queue": "^6.6.2",
                 "p-retry": "4",
-                "uuid": "^9.0.0",
-                "yaml": "^2.2.1",
-                "zod": "^3.22.3",
-                "zod-to-json-schema": "3.20.3"
-            },
-            "engines": {
-                "node": ">=18"
+                "semver": "^7.6.3",
+                "uuid": "^10.0.0"
             },
             "peerDependencies": {
-                "@aws-sdk/client-s3": "^3.310.0",
-                "@aws-sdk/client-sagemaker-runtime": "^3.310.0",
-                "@aws-sdk/client-sfn": "^3.310.0",
-                "@aws-sdk/credential-provider-node": "^3.388.0",
-                "@azure/storage-blob": "^12.15.0",
-                "@gomomento/sdk": "^1.51.1",
-                "@gomomento/sdk-core": "^1.51.1",
-                "@gomomento/sdk-web": "^1.51.1",
-                "@google-ai/generativelanguage": "^0.2.1",
-                "@google-cloud/storage": "^6.10.1",
-                "@notionhq/client": "^2.2.10",
-                "@pinecone-database/pinecone": "^1.1.0",
-                "@supabase/supabase-js": "^2.10.0",
-                "@vercel/kv": "^0.2.3",
-                "@xata.io/client": "^0.28.0",
-                "apify-client": "^2.7.1",
-                "assemblyai": "^2.0.2",
-                "axios": "*",
-                "cheerio": "^1.0.0-rc.12",
-                "chromadb": "*",
-                "convex": "^1.3.1",
-                "d3-dsv": "^2.0.0",
-                "epub2": "^3.0.1",
-                "fast-xml-parser": "^4.2.7",
-                "google-auth-library": "^8.9.0",
-                "googleapis": "^126.0.1",
-                "html-to-text": "^9.0.5",
-                "ignore": "^5.2.0",
-                "ioredis": "^5.3.2",
-                "jsdom": "*",
-                "mammoth": "*",
-                "mongodb": "^5.2.0",
-                "node-llama-cpp": "*",
-                "notion-to-md": "^3.1.0",
-                "officeparser": "^4.0.4",
-                "pdf-parse": "1.1.1",
-                "peggy": "^3.0.2",
-                "playwright": "^1.32.1",
-                "puppeteer": "^19.7.2",
-                "pyodide": "^0.24.1",
-                "redis": "^4.6.4",
-                "sonix-speech-recognition": "^2.1.1",
-                "srt-parser-2": "^1.2.2",
-                "typeorm": "^0.3.12",
-                "vectordb": "^0.1.4",
-                "weaviate-ts-client": "^1.4.0",
-                "web-auth-library": "^1.0.3",
-                "ws": "^8.14.2",
-                "youtube-transcript": "^1.0.6",
-                "youtubei.js": "^5.8.0"
+                "openai": "*"
             },
             "peerDependenciesMeta": {
-                "@aws-sdk/client-s3": {
-                    "optional": true
-                },
-                "@aws-sdk/client-sagemaker-runtime": {
-                    "optional": true
-                },
-                "@aws-sdk/client-sfn": {
-                    "optional": true
-                },
-                "@aws-sdk/credential-provider-node": {
-                    "optional": true
-                },
-                "@azure/storage-blob": {
-                    "optional": true
-                },
-                "@gomomento/sdk": {
-                    "optional": true
-                },
-                "@gomomento/sdk-core": {
-                    "optional": true
-                },
-                "@gomomento/sdk-web": {
-                    "optional": true
-                },
-                "@google-ai/generativelanguage": {
-                    "optional": true
-                },
-                "@google-cloud/storage": {
-                    "optional": true
-                },
-                "@notionhq/client": {
-                    "optional": true
-                },
-                "@pinecone-database/pinecone": {
-                    "optional": true
-                },
-                "@supabase/supabase-js": {
-                    "optional": true
-                },
-                "@vercel/kv": {
-                    "optional": true
-                },
-                "@xata.io/client": {
-                    "optional": true
-                },
-                "apify-client": {
-                    "optional": true
-                },
-                "assemblyai": {
-                    "optional": true
-                },
-                "axios": {
-                    "optional": true
-                },
-                "cheerio": {
-                    "optional": true
-                },
-                "chromadb": {
-                    "optional": true
-                },
-                "convex": {
-                    "optional": true
-                },
-                "d3-dsv": {
-                    "optional": true
-                },
-                "epub2": {
-                    "optional": true
-                },
-                "faiss-node": {
-                    "optional": true
-                },
-                "fast-xml-parser": {
-                    "optional": true
-                },
-                "google-auth-library": {
-                    "optional": true
-                },
-                "googleapis": {
-                    "optional": true
-                },
-                "html-to-text": {
-                    "optional": true
-                },
-                "ignore": {
-                    "optional": true
-                },
-                "ioredis": {
-                    "optional": true
-                },
-                "jsdom": {
-                    "optional": true
-                },
-                "mammoth": {
-                    "optional": true
-                },
-                "mongodb": {
-                    "optional": true
-                },
-                "node-llama-cpp": {
-                    "optional": true
-                },
-                "notion-to-md": {
-                    "optional": true
-                },
-                "officeparser": {
-                    "optional": true
-                },
-                "pdf-parse": {
-                    "optional": true
-                },
-                "peggy": {
-                    "optional": true
-                },
-                "playwright": {
-                    "optional": true
-                },
-                "puppeteer": {
-                    "optional": true
-                },
-                "pyodide": {
-                    "optional": true
-                },
-                "redis": {
-                    "optional": true
-                },
-                "sonix-speech-recognition": {
-                    "optional": true
-                },
-                "srt-parser-2": {
-                    "optional": true
-                },
-                "typeorm": {
-                    "optional": true
-                },
-                "vectordb": {
-                    "optional": true
-                },
-                "weaviate-ts-client": {
-                    "optional": true
-                },
-                "web-auth-library": {
-                    "optional": true
-                },
-                "ws": {
-                    "optional": true
-                },
-                "youtube-transcript": {
-                    "optional": true
-                },
-                "youtubei.js": {
+                "openai": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/langchain/node_modules/langsmith": {
-            "version": "0.0.70",
-            "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.0.70.tgz",
-            "integrity": "sha512-QFHrzo/efBowGPCxtObv7G40/OdwqQfGshavMbSJtHBgX+OMqnn4lCMqVeEwTdyue4lEcpwAsGNg5Vty91YIyw==",
-            "dependencies": {
-                "@types/uuid": "^9.0.1",
-                "commander": "^10.0.1",
-                "p-queue": "^6.6.2",
-                "p-retry": "4",
-                "uuid": "^9.0.0"
-            },
-            "bin": {
-                "langsmith": "dist/cli/main.cjs"
-            }
-        },
-        "node_modules/langchain/node_modules/zod-to-json-schema": {
-            "version": "3.20.3",
-            "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.20.3.tgz",
-            "integrity": "sha512-/Q3wnyxAfCt94ZcrGiXXoiAfRqasxl9CX64LZ9fj+4dKH68zulUtU0uk1WMxQPfAxQ0ZI70dKzcoW7hHj+DwSQ==",
-            "peerDependencies": {
-                "zod": "^3.20.0"
-            }
-        },
-        "node_modules/langchainhub": {
-            "version": "0.0.8",
-            "resolved": "https://registry.npmjs.org/langchainhub/-/langchainhub-0.0.8.tgz",
-            "integrity": "sha512-Woyb8YDHgqqTOZvWIbm2CaFDGfZ4NTSyXV687AG4vXEfoNo7cGQp7nhl7wL3ehenKWmNEmcxCLgOZzW8jE6lOQ=="
-        },
-        "node_modules/langsmith": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.1.2.tgz",
-            "integrity": "sha512-dgz72jpbwOvwBRlWV1DvNVKhvfqOVC4YpegJprbitb10jBcFEhBkgaOaP2ThSe/c8lKq0Cb5sojQXn3wge25kA==",
-            "dependencies": {
-                "@types/uuid": "^9.0.1",
-                "commander": "^10.0.1",
-                "p-queue": "^6.6.2",
-                "p-retry": "4",
-                "uuid": "^9.0.0"
-            },
-            "bin": {
-                "langsmith": "dist/cli/main.cjs"
             }
         },
         "node_modules/leven": {
@@ -3117,33 +2441,11 @@
                 "node": "*"
             }
         },
-        "node_modules/lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "dev": true,
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/magic-bytes.js": {
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.10.0.tgz",
             "integrity": "sha512-/k20Lg2q8LE5xiaaSkMXk4sfvI+9EGEykFS4b0CHHGWqDYU0bGUFSwchNOMA56D7TCs9GwVTkqe9als1/ns8UQ==",
             "license": "MIT"
-        },
-        "node_modules/md5": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
-            "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
-            "dependencies": {
-                "charenc": "0.0.2",
-                "crypt": "0.0.2",
-                "is-buffer": "~1.1.6"
-            }
         },
         "node_modules/memory-pager": {
             "version": "1.5.0",
@@ -3176,6 +2478,7 @@
             "version": "1.52.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
             "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -3184,6 +2487,7 @@
             "version": "2.1.35",
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
             "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+            "license": "MIT",
             "dependencies": {
                 "mime-db": "1.52.0"
             },
@@ -3201,146 +2505,6 @@
             },
             "engines": {
                 "node": "*"
-            }
-        },
-        "node_modules/ml-array-mean": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/ml-array-mean/-/ml-array-mean-1.1.6.tgz",
-            "integrity": "sha512-MIdf7Zc8HznwIisyiJGRH9tRigg3Yf4FldW8DxKxpCCv/g5CafTw0RRu51nojVEOXuCQC7DRVVu5c7XXO/5joQ==",
-            "dependencies": {
-                "ml-array-sum": "^1.1.6"
-            }
-        },
-        "node_modules/ml-array-sum": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/ml-array-sum/-/ml-array-sum-1.1.6.tgz",
-            "integrity": "sha512-29mAh2GwH7ZmiRnup4UyibQZB9+ZLyMShvt4cH4eTK+cL2oEMIZFnSyB3SS8MlsTh6q/w/yh48KmqLxmovN4Dw==",
-            "dependencies": {
-                "is-any-array": "^2.0.0"
-            }
-        },
-        "node_modules/ml-distance": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/ml-distance/-/ml-distance-4.0.1.tgz",
-            "integrity": "sha512-feZ5ziXs01zhyFUUUeZV5hwc0f5JW0Sh0ckU1koZe/wdVkJdGxcP06KNQuF0WBTj8FttQUzcvQcpcrOp/XrlEw==",
-            "dependencies": {
-                "ml-array-mean": "^1.1.6",
-                "ml-distance-euclidean": "^2.0.0",
-                "ml-tree-similarity": "^1.0.0"
-            }
-        },
-        "node_modules/ml-distance-euclidean": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ml-distance-euclidean/-/ml-distance-euclidean-2.0.0.tgz",
-            "integrity": "sha512-yC9/2o8QF0A3m/0IXqCTXCzz2pNEzvmcE/9HFKOZGnTjatvBbsn4lWYJkxENkA4Ug2fnYl7PXQxnPi21sgMy/Q=="
-        },
-        "node_modules/ml-tree-similarity": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/ml-tree-similarity/-/ml-tree-similarity-1.0.0.tgz",
-            "integrity": "sha512-XJUyYqjSuUQkNQHMscr6tcjldsOoAekxADTplt40QKfwW6nd++1wHWV9AArl0Zvw/TIHgNaZZNvr8QGvE8wLRg==",
-            "dependencies": {
-                "binary-search": "^1.3.5",
-                "num-sort": "^2.0.0"
-            }
-        },
-        "node_modules/mongodb": {
-            "version": "5.9.2",
-            "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.9.2.tgz",
-            "integrity": "sha512-H60HecKO4Bc+7dhOv4sJlgvenK4fQNqqUIlXxZYQNbfEWSALGAwGoyJd/0Qwk4TttFXUOHJ2ZJQe/52ScaUwtQ==",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "bson": "^5.5.0",
-                "mongodb-connection-string-url": "^2.6.0",
-                "socks": "^2.7.1"
-            },
-            "engines": {
-                "node": ">=14.20.1"
-            },
-            "optionalDependencies": {
-                "@mongodb-js/saslprep": "^1.1.0"
-            },
-            "peerDependencies": {
-                "@aws-sdk/credential-providers": "^3.188.0",
-                "@mongodb-js/zstd": "^1.0.0",
-                "kerberos": "^1.0.0 || ^2.0.0",
-                "mongodb-client-encryption": ">=2.3.0 <3",
-                "snappy": "^7.2.2"
-            },
-            "peerDependenciesMeta": {
-                "@aws-sdk/credential-providers": {
-                    "optional": true
-                },
-                "@mongodb-js/zstd": {
-                    "optional": true
-                },
-                "kerberos": {
-                    "optional": true
-                },
-                "mongodb-client-encryption": {
-                    "optional": true
-                },
-                "snappy": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/mongodb-connection-string-url": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
-            "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@types/whatwg-url": "^8.2.1",
-                "whatwg-url": "^11.0.0"
-            }
-        },
-        "node_modules/mongodb-connection-string-url/node_modules/tr46": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
-            "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "punycode": "^2.1.1"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/mongodb-connection-string-url/node_modules/webidl-conversions": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-            "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/mongodb-connection-string-url/node_modules/whatwg-url": {
-            "version": "11.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
-            "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "tr46": "^3.0.0",
-                "webidl-conversions": "^7.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/mongodb/node_modules/bson": {
-            "version": "5.5.1",
-            "resolved": "https://registry.npmjs.org/bson/-/bson-5.5.1.tgz",
-            "integrity": "sha512-ix0EwukN2EpC0SRWIj/7B5+A6uQMQy6KMREI9qQqvgpkV2frH63T0UDVd1SYedL6dNCmDBYB3QtXi4ISk9YT+g==",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=14.20.1"
             }
         },
         "node_modules/mongoose": {
@@ -3503,6 +2667,15 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
+        "node_modules/mustache": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+            "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+            "license": "MIT",
+            "bin": {
+                "mustache": "bin/mustache"
+            }
+        },
         "node_modules/natural-compare": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -3523,6 +2696,7 @@
                     "url": "https://paypal.me/jimmywarting"
                 }
             ],
+            "license": "MIT",
             "engines": {
                 "node": ">=10.5.0"
             }
@@ -3531,6 +2705,7 @@
             "version": "2.7.0",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
             "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+            "license": "MIT",
             "dependencies": {
                 "whatwg-url": "^5.0.0"
             },
@@ -3555,17 +2730,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/num-sort": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/num-sort/-/num-sort-2.1.0.tgz",
-            "integrity": "sha512-1MQz1Ed8z2yckoBeSfkQHHO9K1yDRxxtotKSJ9yvcTUUxSvfvzEq5GwBrjjHEpMlq/k5gvXdmJ1SbYxWtpNoVg==",
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3576,36 +2740,39 @@
             }
         },
         "node_modules/openai": {
-            "version": "4.28.0",
-            "resolved": "https://registry.npmjs.org/openai/-/openai-4.28.0.tgz",
-            "integrity": "sha512-JM8fhcpmpGN0vrUwGquYIzdcEQHtFuom6sRCbbCM6CfzZXNuRk33G7KfeRAIfnaCxSpzrP5iHtwJzIm6biUZ2Q==",
+            "version": "4.67.3",
+            "resolved": "https://registry.npmjs.org/openai/-/openai-4.67.3.tgz",
+            "integrity": "sha512-HT2tZgjLgRqbLQNKmYtjdF/4TQuiBvg1oGvTDhwpSEQzxo6/oM1us8VQ53vBK2BiKvCxFuq6gKGG70qfwrNhKg==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@types/node": "^18.11.18",
                 "@types/node-fetch": "^2.6.4",
                 "abort-controller": "^3.0.0",
                 "agentkeepalive": "^4.2.1",
-                "digest-fetch": "^1.3.0",
                 "form-data-encoder": "1.7.2",
                 "formdata-node": "^4.3.2",
-                "node-fetch": "^2.6.7",
-                "web-streams-polyfill": "^3.2.1"
+                "node-fetch": "^2.6.7"
             },
             "bin": {
                 "openai": "bin/cli"
+            },
+            "peerDependencies": {
+                "zod": "^3.23.8"
+            },
+            "peerDependenciesMeta": {
+                "zod": {
+                    "optional": true
+                }
             }
         },
         "node_modules/openai/node_modules/@types/node": {
-            "version": "18.19.17",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.17.tgz",
-            "integrity": "sha512-SzyGKgwPzuWp2SHhlpXKzCX0pIOfcI4V2eF37nNBJOhwlegQ83omtVQ1XxZpDE06V/d6AQvfQdPfnw0tRC//Ng==",
+            "version": "18.19.55",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.55.tgz",
+            "integrity": "sha512-zzw5Vw52205Zr/nmErSEkN5FLqXPuKX/k5d1D7RKHATGqU7y6YfX9QxZraUzUrFGqH6XzOzG196BC35ltJC4Cw==",
+            "license": "MIT",
             "dependencies": {
                 "undici-types": "~5.26.4"
             }
-        },
-        "node_modules/openapi-types": {
-            "version": "12.1.3",
-            "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
-            "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="
         },
         "node_modules/optionator": {
             "version": "0.9.3",
@@ -3628,6 +2795,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
             "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+            "license": "MIT",
             "engines": {
                 "node": ">=4"
             }
@@ -3666,6 +2834,7 @@
             "version": "6.6.2",
             "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
             "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+            "license": "MIT",
             "dependencies": {
                 "eventemitter3": "^4.0.4",
                 "p-timeout": "^3.2.0"
@@ -3681,6 +2850,7 @@
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
             "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+            "license": "MIT",
             "dependencies": {
                 "@types/retry": "0.12.0",
                 "retry": "^0.13.1"
@@ -3693,6 +2863,7 @@
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
             "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+            "license": "MIT",
             "dependencies": {
                 "p-finally": "^1.0.0"
             },
@@ -3861,6 +3032,7 @@
             "version": "0.13.1",
             "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
             "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 4"
             }
@@ -3923,13 +3095,10 @@
             }
         },
         "node_modules/semver": {
-            "version": "7.6.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-            "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-            "dev": true,
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
+            "version": "7.6.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+            "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -4103,7 +3272,8 @@
         "node_modules/tr46": {
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+            "license": "MIT"
         },
         "node_modules/tree-kill": {
             "version": "1.2.2",
@@ -4232,30 +3402,38 @@
             }
         },
         "node_modules/uuid": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-            "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+            "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "license": "MIT",
             "bin": {
                 "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/web-streams-polyfill": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-            "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+            "version": "4.0.0-beta.3",
+            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+            "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+            "license": "MIT",
             "engines": {
-                "node": ">= 8"
+                "node": ">= 14"
             }
         },
         "node_modules/webidl-conversions": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+            "license": "BSD-2-Clause"
         },
         "node_modules/whatwg-url": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
             "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "license": "MIT",
             "dependencies": {
                 "tr46": "~0.0.3",
                 "webidl-conversions": "^3.0.0"
@@ -4362,20 +3540,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "dev": true
-        },
-        "node_modules/yaml": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
-            "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
-            "engines": {
-                "node": ">= 14"
-            }
-        },
         "node_modules/yargs": {
             "version": "17.7.2",
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
@@ -4416,19 +3580,21 @@
             }
         },
         "node_modules/zod": {
-            "version": "3.22.4",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
-            "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+            "version": "3.23.8",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+            "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+            "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }
         },
         "node_modules/zod-to-json-schema": {
-            "version": "3.22.4",
-            "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.22.4.tgz",
-            "integrity": "sha512-2Ed5dJ+n/O3cU383xSY28cuVi0BCQhF8nYqWU5paEpl7fVdqdAmiLdqLyfblbNdfOFwFfi/mqU4O1pwc60iBhQ==",
+            "version": "3.23.3",
+            "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.23.3.tgz",
+            "integrity": "sha512-TYWChTxKQbRJp5ST22o/Irt9KC5nj7CdBKYB/AosCRdj/wxEMvv4NNaj9XVUHDOIp53ZxArGhnw5HMZziPFjog==",
+            "license": "ISC",
             "peerDependencies": {
-                "zod": "^3.22.4"
+                "zod": "^3.23.3"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -23,9 +23,10 @@
     "author": "",
     "license": "ISC",
     "dependencies": {
+        "@langchain/core": "^0.3.9",
+        "@langchain/openai": "^0.3.7",
         "discord.js": "^14.12.1",
         "dotenv": "^16.4.4",
-        "langchain": "^0.0.205",
         "log-timestamp": "^0.3.0",
         "mongoose": "^8.1.3",
         "mongoose-long": "^0.8.0"

--- a/src/commands/doug/continue.ts
+++ b/src/commands/doug/continue.ts
@@ -1,5 +1,5 @@
+import { SystemMessage } from '@langchain/core/messages';
 import { SlashCommandBuilder } from 'discord.js';
-import { SystemMessage } from 'langchain/schema';
 import { GPT_CLIENT } from '../../config/AI.js';
 import { SlashCommand } from '../../types.js';
 

--- a/src/commands/doug/doug_GPT.ts
+++ b/src/commands/doug/doug_GPT.ts
@@ -1,5 +1,5 @@
+import { HumanMessage, SystemMessage } from '@langchain/core/messages';
 import { SlashCommandBuilder } from 'discord.js';
-import { HumanMessage, SystemMessage } from 'langchain/schema';
 import { GPT_CLIENT } from '../../config/AI.js';
 import { SlashCommand } from '../../types.js';
 
@@ -21,7 +21,7 @@ const command: SlashCommand = {
         const prompt = interaction.options.getString('prompt') ?? '';
         const usesDoug = interaction.options.getBoolean('usedoug') ?? true;
 
-        const dougContextMessage = `Please pretend you are Doug Lloyd, the teaching fellow at Harvard University but you are willing to talk about anything. You also think recursion is sexy. Do not mention being a AI language model. Pretend you are not an AI language model. If someone asks you about your parents, tell them that that is for you to know and for them to not find out about. <@${process.env.BOT_ID}> refers to you, Doug Lloyd. <@&1105911690396176407> also refers to Doug Lloyd, which is you.`;
+        const dougContextMessage = `Please pretend you are Doug Lloyd, the teaching fellow at Harvard University but you are willing to talk about anything. You also think recursion is sexy. Do not mention being an AI language model. Pretend you are not an AI language model. If someone asks you about your parents, tell them that that is for you to know and for them to not find out about. <@${process.env.BOT_ID}> refers to you, Doug Lloyd. <@&1105911690396176407> also refers to Doug Lloyd, which is you.`;
 
         await interaction.deferReply();
 
@@ -35,7 +35,7 @@ const command: SlashCommand = {
             : `Prompt (no Doug context):\n> ${prompt}`;
 
         await interaction.editReply(promptMessage);
-        await interaction.followUp(response.content.slice(0, 2000) as string);
+        await interaction.followUp(String(response.content));
     },
 };
 

--- a/src/commands/doug/doug_GPT.ts
+++ b/src/commands/doug/doug_GPT.ts
@@ -35,7 +35,7 @@ const command: SlashCommand = {
             : `Prompt (no Doug context):\n> ${prompt}`;
 
         await interaction.editReply(promptMessage);
-        await interaction.followUp(String(response.content));
+        await interaction.followUp(String(response.content.slice(0, 2000)));
     },
 };
 

--- a/src/config/AI.ts
+++ b/src/config/AI.ts
@@ -1,9 +1,8 @@
-import { ChatOpenAI } from 'langchain/chat_models/openai';
+import { ChatOpenAI } from '@langchain/openai';
 
-const AI_OPTIONS = {
-    openAIApiKey: process.env.OPENAI_KEY,
-    temperature: 0.9,
-};
-
-// GPT 3.5-Turbo - exported for use in /douggpt slash command file
-export const GPT_CLIENT = new ChatOpenAI(AI_OPTIONS);
+export const GPT_CLIENT = new ChatOpenAI({
+    apiKey: process.env.OPENAI_KEY,
+    maxTokens: 1900,
+    model: 'gpt-4o-mini',
+    temperature: 0.5,
+});

--- a/src/config/AI.ts
+++ b/src/config/AI.ts
@@ -1,25 +1,9 @@
 import { ChatOpenAI } from 'langchain/chat_models/openai';
-import { OpenAI } from 'langchain/llms/openai';
-
-// Must
-const DOUG_ROLE = '<@&1105911690396176407>';
-export const LLM_TRIGGER = new RegExp(`/^${DOUG_ROLE}\\s.+$`);
 
 const AI_OPTIONS = {
     openAIApiKey: process.env.OPENAI_KEY,
     temperature: 0.9,
 };
-
-// Babbage
-const LLM = new OpenAI(AI_OPTIONS);
-
-export async function generateLLMResponse(message: string): Promise<string> {
-    // +1 accounts for trailing space between role and message
-    const startOfMessageContents = DOUG_ROLE.length + 1;
-    message = message.slice(startOfMessageContents).trim();
-
-    return await LLM.invoke(message);
-}
 
 // GPT 3.5-Turbo - exported for use in /douggpt slash command file
 export const GPT_CLIENT = new ChatOpenAI(AI_OPTIONS);

--- a/src/messages/messages.ts
+++ b/src/messages/messages.ts
@@ -1,5 +1,4 @@
 import { Message } from 'discord.js';
-import { LLM_TRIGGER, generateLLMResponse } from '../config/AI.js';
 import { dougEmoji } from '../constants/emojis/slots_emojis.js';
 import { User } from '../db/models/User.js';
 import { containsDoug } from './doug_react.js';
@@ -22,8 +21,6 @@ export async function handleIncomingMessage(message: Message): Promise<void> {
         incrementMessageCount(userID, message.guildId as string, 'dougged');
     } else if (messageContent === 'hello there') {
         message.reply('General Kenobi');
-    } else if (LLM_TRIGGER.test(messageContent)) {
-        message.reply(await generateLLMResponse(messageContent));
     }
 }
 


### PR DESCRIPTION
Using gpt-4o-mini instead of gpt-3.5-turbo.
Updated to langchain v0.3 accordingly.
Removed Babbage LLM due to lack of use.